### PR TITLE
Fixed implicit declaration of gai_strerror() compiler warning.

### DIFF
--- a/maxminddb.c
+++ b/maxminddb.c
@@ -1,3 +1,5 @@
+#define _POSIX_C_SOURCE 200112L
+
 #include <netdb.h>
 #include <string.h>
 


### PR DESCRIPTION
Fixed implicit declaration of gai_strerror() compiler warning, that lead to occasional segfaults, i.e. if the address we attempt to look up is invalid